### PR TITLE
Switch to `main` branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@
 # vim: ft=yaml
 ---
 name: Lint
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  pull_request: null
+  push:
+    branches:
+      - main
 
 jobs:
   commit-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read  # for checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@
 # vim: ft=yaml
 ---
 name: Test
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  pull_request: null
+  push:
+    branches:
+      - main
 
 jobs:
   kitchen:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -5,7 +5,7 @@ cobbler-formula
 
 |img_github| |img_sr| |img_pc|
 
-.. |img_github| image:: https://github.com/cobbler/cobbler-formula/actions/workflows/test.yml/badge.svg?branch=master
+.. |img_github| image:: https://github.com/cobbler/cobbler-formula/actions/workflows/test.yml/badge.svg?branch=main
    :alt: GitHub Actions Test Status
    :scale: 100%
    :target: https://github.com/cobbler/cobbler-formula/actions/workflows/test.yml

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branch: 'master',
+  branches: 'main',
   repositoryUrl: 'https://github.com/cobbler/cobbler-formula',
   plugins: [
       ['@semantic-release/commit-analyzer', {


### PR DESCRIPTION
The `master` branch has been renamed to `main` for conformity with other projects in the Cobbler organization. As such the repository needs to follow this rename.