### PR TITLE
Add Cobbler 4.0.0 support

### DIFF
--- a/cobbler/config/file.sls
+++ b/cobbler/config/file.sls
@@ -6,6 +6,8 @@
 {%- set sls_package_install = tplroot ~ '.package.install' %}
 {%- from tplroot ~ "/map.jinja" import mapdata as cobbler with context %}
 {%- from tplroot ~ "/libtofs.jinja" import files_switch with context %}
+{#- Cobbler 4.0.0 merges modules.conf and mongodb.conf into settings.yaml and removes the standalone files. #}
+{%- set legacy_config = salt['pkg.version_cmp'](cobbler.version, '4.0.0') < 0 %}
 
 include:
   - {{ sls_package_install }}
@@ -27,6 +29,7 @@ cobbler-config-file-file-managed:
     - context:
         cobbler: {{ cobbler | json }}
 
+{%- if legacy_config %}
 cobbler-modules-file-file-managed:
   file.managed:
     - name: /etc/cobbler/modules.conf
@@ -60,3 +63,16 @@ cobbler-mongodb-file-file-managed:
       - sls: {{ sls_package_install }}
     - context:
         cobbler: {{ cobbler | json }}
+{%- else %}
+cobbler-modules-file-file-managed:
+  file.absent:
+    - name: /etc/cobbler/modules.conf
+    - require:
+      - sls: {{ sls_package_install }}
+
+cobbler-mongodb-file-file-managed:
+  file.absent:
+    - name: /etc/cobbler/mongodb.conf
+    - require:
+      - sls: {{ sls_package_install }}
+{%- endif %}

--- a/cobbler/files/default/4.0.0/settings.yaml.jinja
+++ b/cobbler/files/default/4.0.0/settings.yaml.jinja
@@ -1,0 +1,373 @@
+# Cobbler settings file
+# THIS FILE IS MANAGED BY SALTSTACK!
+# This config file is in YAML 1.2 format; see "http://yaml.org".
+
+auto_migrate_settings: {{ cobbler['auto_migrate_settings']|yaml_encode }}
+allow_duplicate_hostnames: &allow_duplicate_hostnames false
+allow_duplicate_ips: &allow_duplicate_ips false
+allow_duplicate_macs: &allow_duplicate_macs false
+allow_dynamic_settings: false
+always_write_dhcp_entries: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx64.efi
+    extra_modules:
+      - chain
+      - efinet
+  default-suse-efi:
+    binary_name: grub.efi
+    use_secure_boot_grub: true
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: {{ cobbler['bootloaders']['syslinux']['location']|yaml_encode }}
+syslinux_memdisk_folder: {{ cobbler['bootloaders']['syslinux']['memdisk_location']|yaml_encode }}
+syslinux_pxelinux_folder: {{ cobbler['bootloaders']['syslinux']['pxelinux_location']|yaml_encode }}
+grub2_mod_dir: {{ cobbler['bootloaders']['grub2']['mod_location']|yaml_encode }}
+bootloaders_shim_folder: {{ cobbler['bootloaders']['shim']['location']|yaml_encode }}
+bootloaders_shim_file: {{ cobbler['bootloaders']['shim']['file']|yaml_encode }}
+secure_boot_grub_folder: {{ cobbler['bootloaders']['shim']['location']|yaml_encode }}
+secure_boot_grub_file: "grub.efi"
+bootloaders_ipxe_folder: {{ cobbler['bootloaders']['ipxe']['location']|yaml_encode }}
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "--cachedir=cache --update"
+autoinstall: "built-in-default.ks"
+default_name_servers: []
+default_name_servers_search: []
+{% if not cobbler['authorization']['default_ownership'] -%}
+default_ownership: []
+{% else -%}
+default_ownership:
+{% for owner in cobbler['authorization']['default_ownership'] -%}
+  - {{ owner|yaml_encode }}
+{% endfor -%}
+{% endif %}
+default_password_crypted: {{ cobbler['authentication']['password']|yaml_encode }}
+default_template_type: "cheetah"
+default_virt_bridge: virbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: kvm
+default_virt_disk_driver: "raw"
+dnsmasq_ethers_file: "/etc/ethers"
+dnsmasq_hosts_file: "/var/lib/cobbler/cobbler_hosts"
+enable_ipxe: {{ cobbler['bootloaders']['ipxe']['enabled']|yaml_encode }}
+enable_menu: {{ cobbler['menu']['enabled']|yaml_encode }}
+http_port: 80
+{% if not cobbler.get("default_kernel_options", {}) -%}
+kernel_options: {}
+{% else -%}
+kernel_options:
+  {{ cobbler.get("default_kernel_options", {}) | dict_to_sls_yaml_params | indent }}
+{% endif -%}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_server: 'puppet'
+puppet_version: 2
+puppet_parameterized_classes: true
+manage_dhcp_v6: {{ cobbler['dhcp']['v6']|yaml_encode }}
+manage_dhcp_v4: {{ cobbler['dhcp']['v4']|yaml_encode }}
+next_server_v4: {{ cobbler['nextserver']['v4']|yaml_dquote }}
+next_server_v6: {{ cobbler['nextserver']['v6']|yaml_dquote }}
+manage_dns: {{ cobbler['dns']['enabled']|yaml_encode }}
+bind_chroot_path: ""
+bind_manage_ipmi: true
+bind_zonefile_path: {{ cobbler['dns']['bind']['location']|yaml_encode }}
+bind_master: {{ cobbler['dns']['bind']['master']|yaml_encode }}
+{% if not cobbler['dns']['bind']['forward_zones'] -%}
+manage_forward_zones: []
+{% else -%}
+manage_forward_zones:
+{% for zone in cobbler['dns']['bind']['forward_zones'] -%}
+  - {{ zone|yaml_encode }}
+{% endfor -%}
+{% endif %}
+{% if not cobbler['dns']['bind']['reverse_zones'] -%}
+manage_reverse_zones: []
+{% else -%}
+manage_reverse_zones:
+{% for zone in cobbler['dns']['bind']['reverse_zones'] -%}
+  - {{ zone|yaml_encode }}
+{% endfor -%}
+{% endif %}
+manage_genders: false
+manage_tftpd: {{ cobbler['tftp']['enabled']|yaml_encode }}
+tftpboot_location: {{ cobbler['tftp']['location']|yaml_encode }}
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+manage_rsync: {{ cobbler['rsync']['enabled']|yaml_encode }}
+power_management_default_type: {{ cobbler['power_management']['default_type']|yaml_dquote }}
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+uyuni_authentication_endpoint: ""
+redhat_management_permissive: false
+redhat_management_key: ""
+redhat_management_org: ""
+redhat_management_user: ""
+redhat_management_password: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: {{ cobbler['scm_track']['enabled']|yaml_encode }}
+scm_track_mode: {{ cobbler['scm_track']['mode']|yaml_dquote }}
+scm_track_author: {{ cobbler['scm_track']['author']|yaml_dquote }}
+scm_push_script: {{ cobbler['scm_track']['push_script']|yaml_dquote }}
+server: {{ cobbler['server']|yaml_dquote }}
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "{{ cobbler['webdir'] }}/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+proxy_url_ext: ""
+proxy_url_int: ""
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json"
+nsupdate_enabled: false
+nsupdate_tsig_algorithm: "hmac-sha512"
+nsupdate_tsig_key: [ "cobbler_update_key.", "hvnK54HFJXFasHjzjEn09ASIkCOGYSnofRq4ejsiBHz3udVyGiuebFGAswSjKUxNuhmllPrkI0HRSSmM2qvZug==" ]
+nsupdate_log: "/var/log/cobbler/nsupdate.log"
+windows_enabled: false
+samba_distro_share: "DISTRO"
+
+# Cobbler modules.conf replacement
+modules:
+  authentication:
+    module: "authentication.{{ cobbler['authentication']['module'] }}"
+    hash_algorithm: "sha3_512"
+  authorization:
+    module: "authorization.{{ cobbler['authorization']['module'] }}"
+  dns:
+    module: "managers.{{ cobbler['dns']['module'] }}"
+  dhcp:
+    module: "managers.{{ cobbler['dhcp']['module'] }}"
+  tftpd:
+    module: "managers.{{ cobbler['tftp']['module'] }}"
+  serializers:
+    module: "serializers.file"
+
+# mongodb.conf replacement
+mongodb:
+  host: "localhost"
+  port: 27017
+
+cache_enabled: false
+autoinstall_scheme: "http"
+lazy_start: false
+
+memory_indexes:
+    distro:
+        name:
+            nonunique: false
+            disabled: false
+        arch:
+            nonunique: true
+            disabled: false
+    image:
+        name:
+            nonunique: false
+            disabled: false
+        arch:
+            nonunique: true
+            disabled: false
+        menu:
+            nonunique: true
+            disabled: false
+    menu:
+        name:
+            nonunique: false
+            disabled: false
+        parent:
+            property: "get_parent"
+            nonunique: true
+            disabled: false
+    profile:
+        name:
+            nonunique: false
+            disabled: false
+        parent:
+            property: "get_parent"
+            nonunique: true
+            disabled: false
+        distro:
+            nonunique: true
+            disabled: false
+        arch:
+            nonunique: true
+            disabled: false
+        menu:
+            nonunique: true
+            disabled: false
+        repos:
+            nonunique: true
+            disabled: false
+    repo:
+        name:
+            nonunique: false
+            disabled: false
+    system:
+        name:
+            nonunique: false
+            disabled: false
+        image:
+            nonunique: true
+            disabled: false
+        profile:
+            nonunique: true
+            disabled: false
+    network_interface:
+        name:
+            nonunique: true
+            disabled: false
+        mac_address:
+            nonunique: *allow_duplicate_macs
+            disabled: *allow_duplicate_macs
+        ipv4.address:
+            nonunique: *allow_duplicate_ips
+            disabled: *allow_duplicate_ips
+        ipv6.address:
+            nonunique: *allow_duplicate_ips
+            disabled: *allow_duplicate_ips
+        dns.name:
+            nonunique: *allow_duplicate_hostnames
+            disabled: *allow_duplicate_hostnames
+    distro_group:
+      name:
+        nonunique: false
+        disabled: false
+    profile_group:
+      name:
+        nonunique: false
+        disabled: false
+    system_group:
+      name:
+        nonunique: false
+        disabled: false

--- a/cobbler/package/repository.sls
+++ b/cobbler/package/repository.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-# Cobbler 3.4.x - https://build.opensuse.org/project/show/systemsmanagement:cobbler:release34
+# Cobbler 4.0.x - https://build.opensuse.org/project/show/systemsmanagement:cobbler:release40
 # Cobbler 3.3.x - https://build.opensuse.org/project/show/systemsmanagement:cobbler:release33
 # Cobbler 3.2.x - https://build.opensuse.org/project/show/systemsmanagement:cobbler:release32
 # Cobbler 3.1.x - https://build.opensuse.org/project/show/systemsmanagement:cobbler:release31
@@ -14,7 +14,7 @@
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- from tplroot ~ "/map.jinja" import mapdata as cobbler with context %}
 {%- set repo_version = {
-  "3.4.x": "release34",
+  "4.0.x": "release40",
   "3.3.x": "release33",
   "3.2.x": "release32",
   "3.1.x": "release31",
@@ -24,7 +24,17 @@
   "2.4.x": "release24",
 }.get(cobbler.pkg.communityrepo.version) %}
 {%- set repo_os_name = {
-  "3.4.x": {},
+  "4.0.x": {
+    "openSUSE Tumbleweed": {
+      "": "openSUSE_Tumbleweed"
+    },
+    "Leap": {
+      "16.0": "16.0",
+    },
+    "Debian": {
+      "13": "Debian_13",
+    },
+  },
   "3.3.x": {
     "openSUSE Tumbleweed": {
       "": "openSUSE_Tumbleweed"

--- a/cobbler/parameters/defaults.yaml
+++ b/cobbler/parameters/defaults.yaml
@@ -12,7 +12,8 @@ values:
     communityrepo:
       # This is mutually exclusive with "epel"!
       enabled: false
-      # Available: "2.4.x", "2.6.x", "2.8.x", "3.0.x", "3.1.x", "3.2.x", "3.3.x"
+      # Available: "2.4.x", "2.6.x", "2.8.x", "3.0.x", "3.1.x", "3.2.x",
+      # "3.3.x", "4.0.x"
       version: "3.3.x"
     epel:
       # This is mutually exclusive with "communityrepo"!


### PR DESCRIPTION
This PR adds support for Cobbler 4.0.0.

Due to the use of semantic-release, it can only be merged after the first release has been published.